### PR TITLE
Introduce migration between minor versions

### DIFF
--- a/src/main/java/info/novatec/bpm/camunda/migrator/MigrationInstructions.java
+++ b/src/main/java/info/novatec/bpm/camunda/migrator/MigrationInstructions.java
@@ -1,0 +1,45 @@
+package info.novatec.bpm.camunda.migrator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+
+/**
+ * Class containing all minor migration instructions for all process
+ * definitions. A Bean of this class needs to be provided for the
+ * {@link ProcessInstanceMigrator}, even if no instructions are specified.
+ */
+@Getter
+public class MigrationInstructions {
+	    
+	private Map<String, List<MinorMigrationInstructions>> migrationInstructionMap;
+	
+	private MigrationInstructions(Map<String, List<MinorMigrationInstructions>> migrationInstructionMap) {
+		this.migrationInstructionMap = migrationInstructionMap;
+	}
+	    
+	public static class Builder {
+		private Map<String, List<MinorMigrationInstructions>> migrationInstructionMap;
+		
+		public Builder() {
+			this.migrationInstructionMap = new HashMap<>();
+		}
+		
+		public Builder putInstructions(String processDefinitionKey, List<MinorMigrationInstructions> instructions) {
+			if (migrationInstructionMap.containsKey(processDefinitionKey)) {
+				migrationInstructionMap.get(processDefinitionKey).addAll(instructions);
+			} else {
+				//generate new ArrayList to guarantee support for structural modification (i.e. add)
+				migrationInstructionMap.put(processDefinitionKey, new ArrayList<>(instructions));
+			}
+			return this;
+		}
+		
+		public MigrationInstructions build() {
+			return new MigrationInstructions(migrationInstructionMap);			
+		}
+	}
+}

--- a/src/main/java/info/novatec/bpm/camunda/migrator/MigrationInstructions.java
+++ b/src/main/java/info/novatec/bpm/camunda/migrator/MigrationInstructions.java
@@ -13,7 +13,8 @@ import lombok.Getter;
  * {@link ProcessInstanceMigrator}, even if no instructions are specified.
  */
 @Getter
-public class MigrationInstructions {
+public class MigrationInstructions //für alle Prozessdefinitionen: für alle Minor-Migrationen: alle Instruktionen 
+{
 	    
 	private Map<String, List<MinorMigrationInstructions>> migrationInstructionMap;
 	

--- a/src/main/java/info/novatec/bpm/camunda/migrator/MinorMigrationInstructions.java
+++ b/src/main/java/info/novatec/bpm/camunda/migrator/MinorMigrationInstructions.java
@@ -1,0 +1,28 @@
+package info.novatec.bpm.camunda.migrator;
+
+import java.util.List;
+
+
+import org.camunda.bpm.engine.migration.MigrationInstruction;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Data-Class for migration instructions linked to a single minor migration of a
+ * process instance. Contains the migrations source minor version, its target
+ * minor version, a list of migration instructions and the major version of
+ * source and target version 
+ */
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class MinorMigrationInstructions {
+    private final int sourceMinorVersion;
+    private final int targetMinorVersion;
+    @NonNull
+    private final List<MigrationInstruction> migrationInstructions;
+    private final int majorVersion;
+}

--- a/src/main/java/info/novatec/bpm/camunda/migrator/ProcessInstanceMigrator.java
+++ b/src/main/java/info/novatec/bpm/camunda/migrator/ProcessInstanceMigrator.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.migration.MigrationInstructionImpl;
 import org.camunda.bpm.engine.migration.MigrationInstruction;
@@ -18,10 +16,6 @@ import org.camunda.bpm.engine.runtime.ProcessInstance;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * This migrator will, upon deployment, attempt to migrate all existing process instances that come from a process
@@ -38,7 +32,6 @@ public class ProcessInstanceMigrator {
 
     private final ProcessEngine processEngine;
     
-    @Autowired
     private final MigrationInstructions migrationInstructions;
 
     private static final ProcessVersion OLDEST_RELEASED_VERSION = ProcessVersion.fromString("1.0.0");

--- a/src/main/java/info/novatec/bpm/camunda/migrator/ProcessVersion.java
+++ b/src/main/java/info/novatec/bpm/camunda/migrator/ProcessVersion.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class ProcessVersion {
+
     private final int majorVersion;
     private final int minorVersion;
     private final int patchVersion;
@@ -20,20 +21,22 @@ public class ProcessVersion {
 
     public boolean isOlderVersionThan(ProcessVersion processVersionToCompare) {
         return this.majorVersion < processVersionToCompare.getMajorVersion()
-               || (this.majorVersion == processVersionToCompare.getMajorVersion() && this.minorVersion < processVersionToCompare.getMinorVersion())
-               || (this.majorVersion == processVersionToCompare.getMajorVersion() && this.minorVersion == processVersionToCompare.getMinorVersion()
-                   && this.patchVersion < processVersionToCompare.getPatchVersion());
+            || (this.majorVersion == processVersionToCompare.getMajorVersion()
+                && this.minorVersion < processVersionToCompare.getMinorVersion())
+            || (this.majorVersion == processVersionToCompare.getMajorVersion()
+                && this.minorVersion == processVersionToCompare.getMinorVersion()
+                && this.patchVersion < processVersionToCompare.getPatchVersion());
     }
 
     public boolean isOlderPatchThan(ProcessVersion processVersionToCompare) {
         return this.majorVersion == processVersionToCompare.getMajorVersion()
-                && this.minorVersion == processVersionToCompare.getMinorVersion()
-                && this.patchVersion < processVersionToCompare.getPatchVersion();
+            && this.minorVersion == processVersionToCompare.getMinorVersion()
+            && this.patchVersion < processVersionToCompare.getPatchVersion();
     }
 
     public boolean isOlderMinorThan(ProcessVersion processVersionToCompare) {
         return this.majorVersion == processVersionToCompare.getMajorVersion()
-                && this.minorVersion <  processVersionToCompare.getMinorVersion();
+            && this.minorVersion < processVersionToCompare.getMinorVersion();
     }
 
     public boolean isOlderMajorThan(ProcessVersion processVersionToCompare) {

--- a/src/test/java/info/novatec/bpm/camunda/migrator/ProcessInstanceMigratorTest.java
+++ b/src/test/java/info/novatec/bpm/camunda/migrator/ProcessInstanceMigratorTest.java
@@ -2,7 +2,12 @@ package info.novatec.bpm.camunda.migrator;
 
 import static info.novatec.bpm.camunda.migrator.assertions.ProcessInstanceListAsserter.assertThat;
 import static info.novatec.bpm.camunda.migrator.assertions.TaskListAsserter.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.camunda.bpm.engine.impl.migration.MigrationInstructionImpl;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
@@ -12,34 +17,32 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ProcessInstanceMigratorTest {
 
     @ClassRule
     public static ProcessEngineRule rule = new ProcessEngineRule();
 
     protected static final String MIGRATEABLE_PROCESS_MODEL_PATH = "test-processmodels/migrateable_processmodel_1_0_0.bpmn";
-    private static final String UPDATED_PROCESS_MODEL_PATH = "test-processmodels/migrateable_processmodel_1_0_1_with_formkeys.bpmn";
+    private static final String PATCHED_PROCESS_MODEL_PATH = "test-processmodels/migrateable_processmodel_1_0_1_with_formkeys.bpmn";
     private static final String MINOR_INCREASED_PROCESS_MODEL_PATH = "test-processmodels/migrateable_processmodel_1_5_0.bpmn";
+    private static final String MINOR_INCREASED_AND_PATCHED_PROCESS_MODEL_PATH = "test-processmodels/migrateable_processmodel_1_5_1.bpmn";
     private static final String MAJOR_INCREASED_PROCESS_MODEL_PATH = "test-processmodels/migrateable_processmodel_2_0_0.bpmn";
 
     private static final String PROCESS_DEFINITION_KEY = "MigrateableProcess";
 
-    private ProcessInstanceMigrator processInstanceMigrator = new ProcessInstanceMigrator(rule.getProcessEngine());
+    private ProcessInstanceMigrator processInstanceMigrator = new ProcessInstanceMigrator(rule.getProcessEngine(), new MigrationInstructions.Builder().build());
 
-    private ProcessDefinition newestProcessDefinition;
+    private ProcessDefinition initialProcessDefinition;
+    private ProcessDefinition newestProcessDefinitionAfterRedeployment;
     private ProcessInstance processInstance1;
     private ProcessInstance processInstance2;
 
     @Before
     public void setUp() {
         deployBPMNFromClasspathResource(MIGRATEABLE_PROCESS_MODEL_PATH);
-        //this will refer to the initial process Model
-        newestProcessDefinition = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
-        assertThat(newestProcessDefinition.getVersionTag()).isEqualTo("1.0.0");
+        // this will refer to the initial process Model
+        initialProcessDefinition = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        assertThat(initialProcessDefinition.getVersionTag()).isEqualTo("1.0.0");
 
         processInstance1 = startProcessInstance(PROCESS_DEFINITION_KEY);
         processInstance2 = startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -50,23 +53,26 @@ public class ProcessInstanceMigratorTest {
         rule.getRuntimeService().deleteProcessInstance(processInstance1.getId(), "noReason");
         rule.getRuntimeService().deleteProcessInstance(processInstance2.getId(), "noReason");
 
-        rule.getRepositoryService().createDeploymentQuery().list().forEach(
+        rule.getRepositoryService()
+            .createDeploymentQuery()
+            .list()
+            .forEach(
                 deployment -> rule.getRepositoryService().deleteDeployment(deployment.getId()));
     }
 
     @Test
     public void processInstanceMigrator_should_migrate_all_process_instances_to_higher_patch() {
-        deployBPMNFromClasspathResource(UPDATED_PROCESS_MODEL_PATH);
-        ProcessDefinition newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        deployBPMNFromClasspathResource(PATCHED_PROCESS_MODEL_PATH);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
         assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.0.1");
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
 
         processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
@@ -86,18 +92,18 @@ public class ProcessInstanceMigratorTest {
         suspendProcessInstance(processInstance1);
         suspendProcessInstance(processInstance2);
 
-        deployBPMNFromClasspathResource(UPDATED_PROCESS_MODEL_PATH);
-        ProcessDefinition newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        deployBPMNFromClasspathResource(PATCHED_PROCESS_MODEL_PATH);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
         assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.0.1");
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId())
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId())
             .allProcessInstancesAreSuspended();
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
 
         processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
@@ -115,19 +121,19 @@ public class ProcessInstanceMigratorTest {
 
     @Test
     public void processInstanceMigrator_should_migrate_from_suspended_process_definitions() {
-        suspendProcessDefinition(newestProcessDefinition);
+        suspendProcessDefinition(initialProcessDefinition);
 
-        deployBPMNFromClasspathResource(UPDATED_PROCESS_MODEL_PATH);
-        ProcessDefinition newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        deployBPMNFromClasspathResource(PATCHED_PROCESS_MODEL_PATH);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
         assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.0.1");
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
-        .numberOfProcessInstancesIs(2)
-        .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .numberOfProcessInstancesIs(2)
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
 
         processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
@@ -144,89 +150,216 @@ public class ProcessInstanceMigratorTest {
 
     @Test
     public void processInstanceMigrator_should_not_migrate_to_suspended_process_definitions() {
-        deployBPMNFromClasspathResource(UPDATED_PROCESS_MODEL_PATH);
-        ProcessDefinition newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        deployBPMNFromClasspathResource(PATCHED_PROCESS_MODEL_PATH);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
         assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.0.1");
 
         suspendProcessDefinition(newestProcessDefinitionAfterRedeployment);
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
 
         processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
     }
 
     @Test
-    public void processInstanceMigrator_should_not_migrate_to_higher_minor_version() {
+    public void processInstanceMigrator_should_not_migrate_to_higher_minor_version_if_no_migration_plan_was_provided() {
         deployBPMNFromClasspathResource(MINOR_INCREASED_PROCESS_MODEL_PATH);
-        ProcessDefinition newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
         assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.5.0");
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
 
         processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
+    }
+
+    @Test
+    public void processInstanceMigrator_should_migrate_to_higher_minor_version_if_migration_plan_was_provided() {
+        deployBPMNFromClasspathResource(MINOR_INCREASED_PROCESS_MODEL_PATH);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.5.0");
+
+        assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
+            .numberOfProcessInstancesIs(2)
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
+
+        assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
+            .numberOfTasksIs(2)
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
+            .allTasksHaveKey("UserTask1")
+            .allTasksHaveFormkey(null);
+
+		processInstanceMigrator = new ProcessInstanceMigrator(rule.getProcessEngine(),
+				new MigrationInstructions.Builder()
+						.putInstructions(PROCESS_DEFINITION_KEY, generateMigrationInstructionsFor100To150())
+						.build());
+        processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
+
+        assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
+            .numberOfProcessInstancesIs(2)
+            .allProcessInstancesHaveDefinitionId(newestProcessDefinitionAfterRedeployment.getId());
+
+        assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
+            .numberOfTasksIs(2)
+            .allTasksHaveDefinitionId(newestProcessDefinitionAfterRedeployment.getId())
+            .allTasksHaveKey("UserTask2")
+            .allTasksHaveFormkey("Formkey2");
+    }
+
+    @Test
+    public void processInstanceMigrator_should_migrate_to_higher_minor_by_adding_up_migration_instructions() {
+        deployBPMNFromClasspathResource(MINOR_INCREASED_PROCESS_MODEL_PATH);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.5.0");
+
+        assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
+            .numberOfProcessInstancesIs(2)
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
+
+        assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
+            .numberOfTasksIs(2)
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
+            .allTasksHaveKey("UserTask1")
+            .allTasksHaveFormkey(null);
+
+        processInstanceMigrator = new ProcessInstanceMigrator(rule.getProcessEngine(),
+				new MigrationInstructions.Builder()
+						.putInstructions(PROCESS_DEFINITION_KEY, generateMigrationInstructionFor100To130())
+						.putInstructions(PROCESS_DEFINITION_KEY, generateMigrationInstructionFor130To150())
+						.build());
+        processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
+
+        assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
+            .numberOfProcessInstancesIs(2)
+            .allProcessInstancesHaveDefinitionId(newestProcessDefinitionAfterRedeployment.getId());
+
+        assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
+            .numberOfTasksIs(2)
+            .allTasksHaveDefinitionId(newestProcessDefinitionAfterRedeployment.getId())
+            .allTasksHaveKey("UserTask2")
+            .allTasksHaveFormkey("Formkey2");
+    }
+    
+    @Test
+    public void processInstanceMigrator_should_migrate_to_higher_minor_and_patch_version_using_only_minor_migration_plan() {
+    	deployBPMNFromClasspathResource(MINOR_INCREASED_AND_PATCHED_PROCESS_MODEL_PATH);
+    	newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("1.5.1");
+        
+        assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
+	        .numberOfProcessInstancesIs(2)
+	        .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
+	
+	    assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
+	        .numberOfTasksIs(2)
+	        .allTasksHaveDefinitionId(initialProcessDefinition.getId())
+	        .allTasksHaveKey("UserTask1")
+	        .allTasksHaveFormkey(null);
+	
+		processInstanceMigrator = new ProcessInstanceMigrator(rule.getProcessEngine(),
+				new MigrationInstructions.Builder()
+						.putInstructions(PROCESS_DEFINITION_KEY, generateMigrationInstructionsFor100To150())
+						.build());
+	    processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
+	
+	    assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
+	        .numberOfProcessInstancesIs(2)
+	        .allProcessInstancesHaveDefinitionId(newestProcessDefinitionAfterRedeployment.getId());
+	
+	    assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
+	        .numberOfTasksIs(2)
+	        .allTasksHaveDefinitionId(newestProcessDefinitionAfterRedeployment.getId())
+	        .allTasksHaveKey("UserTask2")
+	        .allTasksHaveFormkey("Formkey2");
     }
 
     @Test
     public void processInstanceMigrator_should_not_migrate_to_higher_major_version() {
         deployBPMNFromClasspathResource(MAJOR_INCREASED_PROCESS_MODEL_PATH);
-        ProcessDefinition newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
+        newestProcessDefinitionAfterRedeployment = getNewestDeployedProcessDefinitionId(PROCESS_DEFINITION_KEY);
         assertThat(newestProcessDefinitionAfterRedeployment.getVersionTag()).isEqualTo("2.0.0");
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
 
         processInstanceMigrator.migrateProcessInstances(PROCESS_DEFINITION_KEY);
 
         assertThat(getRunningProcessInstances(PROCESS_DEFINITION_KEY))
             .numberOfProcessInstancesIs(2)
-            .allProcessInstancesHaveDefinitionId(newestProcessDefinition.getId());
+            .allProcessInstancesHaveDefinitionId(initialProcessDefinition.getId());
 
         assertThat(getCurrentTasks(PROCESS_DEFINITION_KEY))
             .numberOfTasksIs(2)
-            .allTasksHaveDefinitionId(newestProcessDefinition.getId())
+            .allTasksHaveDefinitionId(initialProcessDefinition.getId())
             .allTasksHaveFormkey(null);
     }
 
+    private List<MinorMigrationInstructions> generateMigrationInstructionsFor100To150() {
+        return Arrays.asList(MinorMigrationInstructions.builder()
+        		.sourceMinorVersion(0)
+        		.targetMinorVersion(5)
+        		.migrationInstructions(Arrays.asList(new MigrationInstructionImpl("UserTask1", "UserTask2")))
+        		.majorVersion(1)
+        		.build());
+    }
+
+    private List<MinorMigrationInstructions> generateMigrationInstructionFor100To130() {
+        return Arrays.asList(MinorMigrationInstructions.builder()
+        		.sourceMinorVersion(0)
+        		.targetMinorVersion(3)
+        		.migrationInstructions(Arrays.asList(new MigrationInstructionImpl("UserTask1", "UserTask3")))
+        		.majorVersion(1)
+        		.build());
+    }
+
+    private List<MinorMigrationInstructions> generateMigrationInstructionFor130To150() {
+        return Arrays.asList(MinorMigrationInstructions.builder()
+        		.sourceMinorVersion(3)
+        		.targetMinorVersion(5)
+        		.migrationInstructions(Arrays.asList(new MigrationInstructionImpl("UserTask3", "UserTask2")))
+        		.majorVersion(1)
+        		.build());
+    }
+
     private void suspendProcessInstance(ProcessInstance processInstance) {
-       rule.getRuntimeService().suspendProcessInstanceById(processInstance.getId());
+        rule.getRuntimeService().suspendProcessInstanceById(processInstance.getId());
     }
 
     private void suspendProcessDefinition(ProcessDefinition processDefinition) {
@@ -234,25 +367,26 @@ public class ProcessInstanceMigratorTest {
     }
 
     private ProcessDefinition getNewestDeployedProcessDefinitionId(String processDefinitionKey) {
-        return rule.getRepositoryService().createProcessDefinitionQuery()
-                .processDefinitionKey(processDefinitionKey)
-                .latestVersion()
-                .singleResult();
+        return rule.getRepositoryService()
+            .createProcessDefinitionQuery()
+            .processDefinitionKey(processDefinitionKey)
+            .latestVersion()
+            .singleResult();
     }
 
     private List<ProcessInstance> getRunningProcessInstances(String processDefinitionKey) {
         return rule.getRuntimeService()
-                .createProcessInstanceQuery()
-                .processDefinitionKey(processDefinitionKey)
-                .list();
+            .createProcessInstanceQuery()
+            .processDefinitionKey(processDefinitionKey)
+            .list();
     }
 
-    private List<Task> getCurrentTasks(String processDefinitionKey){
+    private List<Task> getCurrentTasks(String processDefinitionKey) {
         return rule.getTaskService()
-                .createTaskQuery()
-                .processDefinitionKey(processDefinitionKey)
-                .initializeFormKeys()
-                .list();
+            .createTaskQuery()
+            .processDefinitionKey(processDefinitionKey)
+            .initializeFormKeys()
+            .list();
     }
 
     private void deployBPMNFromClasspathResource(String path) {

--- a/src/test/java/info/novatec/bpm/camunda/migrator/assertions/TaskListAsserter.java
+++ b/src/test/java/info/novatec/bpm/camunda/migrator/assertions/TaskListAsserter.java
@@ -42,4 +42,10 @@ public class TaskListAsserter {
                 task -> Assertions.assertThat(key).isEqualTo(task.getTaskDefinitionKey()));
         return this;
     }
+    
+    public TaskListAsserter oneTaskHasKey(String key) {
+    	tasks.stream()
+    		.anyMatch(task -> key.equals(task.getTaskDefinitionKey()));
+    	return this;
+    }
 }

--- a/src/test/java/info/novatec/bpm/camunda/migrator/assertions/TaskListAsserter.java
+++ b/src/test/java/info/novatec/bpm/camunda/migrator/assertions/TaskListAsserter.java
@@ -1,9 +1,11 @@
 package info.novatec.bpm.camunda.migrator.assertions;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.camunda.bpm.engine.task.Task;
-import java.util.List;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class TaskListAsserter {
@@ -15,8 +17,10 @@ public class TaskListAsserter {
     }
 
     public TaskListAsserter allTasksHaveDefinitionId(String processDefinitionId) {
-        Assertions.assertThat(tasks.stream().allMatch(
-                task -> processDefinitionId.equals(task.getProcessDefinitionId()))).isTrue();
+        Assertions.assertThat(tasks.stream()
+            .allMatch(
+                task -> processDefinitionId.equals(task.getProcessDefinitionId())))
+            .isTrue();
         return this;
     }
 
@@ -26,8 +30,16 @@ public class TaskListAsserter {
     }
 
     public TaskListAsserter allTasksHaveFormkey(String formKey) {
-        Assertions.assertThat(tasks.stream().allMatch(
-                task -> formKey == task.getFormKey()));
+        tasks.stream()
+            .forEach(
+                task -> Assertions.assertThat(formKey).isEqualTo(task.getFormKey()));
+        return this;
+    }
+
+    public TaskListAsserter allTasksHaveKey(String key) {
+        tasks.stream()
+            .forEach(
+                task -> Assertions.assertThat(key).isEqualTo(task.getTaskDefinitionKey()));
         return this;
     }
 }

--- a/src/test/resources/test-processmodels/migrateable_processmodel_1_5_1.bpmn
+++ b/src/test/resources/test-processmodels/migrateable_processmodel_1_5_1.bpmn
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gkaqyk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.4">
-  <bpmn:process id="MigrateableProcess" name="Migrateable Process" isExecutable="true" camunda:versionTag="1.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gkaqyk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+  <bpmn:process id="MigrateableProcess" name="Migrateable Process" isExecutable="true" camunda:versionTag="1.5.1">
     <bpmn:startEvent id="StartEvent_1" name="Process started">
       <bpmn:outgoing>SequenceFlow_097y2v3</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_097y2v3" sourceRef="StartEvent_1" targetRef="UserTask2" />
-    <bpmn:userTask id="UserTask2" name="Do another thing" camunda:formKey="Formkey2">
+    <bpmn:userTask id="UserTask2" name="Do another thing (renamed)" camunda:formKey="Formkey2">
       <bpmn:incoming>SequenceFlow_097y2v3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_03yewvu</bpmn:outgoing>
     </bpmn:userTask>
@@ -16,16 +16,20 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MigrateableProcess">
+      <bpmndi:BPMNEdge id="SequenceFlow_03yewvu_di" bpmnElement="SequenceFlow_03yewvu">
+        <di:waypoint x="534" y="117" />
+        <di:waypoint x="842" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_097y2v3_di" bpmnElement="SequenceFlow_097y2v3">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="434" y="117" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="159" y="142" width="77" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_097y2v3_di" bpmnElement="SequenceFlow_097y2v3">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="434" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="UserTask_1feyd6u_di" bpmnElement="UserTask2">
         <dc:Bounds x="434" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -35,10 +39,6 @@
           <dc:Bounds x="824" y="142" width="74" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_03yewvu_di" bpmnElement="SequenceFlow_03yewvu">
-        <di:waypoint x="534" y="117" />
-        <di:waypoint x="842" y="117" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
This should allow users to specify migration instructions for migration between minor versions (i.e. 1.4.0 -> 1.5.0), therefore allowing migration of process models where tasks were deleted or renamed.